### PR TITLE
[KW-302] feat: 401 에러 발생 시 리프레시 토큰 기반 엑세스 토큰 재발급

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment variables
+.env
+.env.*

--- a/src/contexts/axiosWithAuthorization.tsx
+++ b/src/contexts/axiosWithAuthorization.tsx
@@ -1,0 +1,66 @@
+import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+const getAccessToken = (): string | null => {
+  return localStorage.getItem("accessToken");
+};
+
+const axiosWithAuthorization: AxiosInstance = axios.create({
+  baseURL: import.meta.env.VITE_PUBLIC_KEYWE_SERVER_URI,
+  withCredentials: true,
+});
+
+// 요청 인터셉터
+axiosWithAuthorization.interceptors.request.use((config) => {
+  const token = getAccessToken();
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+// 응답 인터셉터
+axiosWithAuthorization.interceptors.response.use(
+  (response: AxiosResponse) => response,
+  async (error: AxiosError) => {
+    const originalRequest = error.config as AxiosRequestConfig & { _retry?: boolean };
+
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      console.warn("401 에러 발생하여 엑세스 토큰 재발급 시도");
+
+      try {
+        const res = await axios.post(
+          "/auth/reissue",
+          {},
+          {
+            headers: {
+              Authorization: `Bearer ${getAccessToken()}`
+            },
+            withCredentials: true,
+          }
+        );
+
+        const newAccessToken = res.headers["authorization"];
+        if (newAccessToken) {
+          const tokenValue = newAccessToken.replace("Bearer ", "");
+          localStorage.setItem("accessToken", tokenValue);
+
+          originalRequest.headers = originalRequest.headers || {};
+          originalRequest.headers.Authorization = `Bearer ${tokenValue}`;
+          console.info("엑세스 토큰 재발급 성공 및 재요청 수행");
+
+          return axiosWithAuthorization(originalRequest); 
+        }
+        // 엑세스 토큰을 받지 못했을 경우
+        return Promise.reject(new Error("새로운 accessToken을 받지 못했습니다."));
+      } catch (refreshError) {
+        console.error("엑세스 토큰 재발급 실패:", refreshError);
+        window.location.href = "/admin/login";
+        return Promise.reject(refreshError);
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
+
+export default axiosWithAuthorization;


### PR DESCRIPTION
## 🔷 관련 Jira Ticket ID

[KW-302]

---
## 📌 작업 내용 및 특이사항

- 인증이 필요한 API 요청 시 엑세스 토큰이 만료되어 401 에러가 발생할 경우, 리프레시 토큰을 이용해 엑세스 토큰을 재발급하고 기존 요청을 재시도하는 axiosWithAuthorization 모듈을 작성하였습니다.
- 재발급에 성공하면 새로운 엑세스 토큰을 로컬 스토리지에 저장하고 실패 시 로그인 페이지로 리다이렉트되도록 처리하였습니다.
---
## 📚 참고사항

-


[KW-302]: https://teamdoubleo.atlassian.net/browse/KW-302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ