### PR TITLE
[KW-318] fix: 리프레시 토큰으로 엑세스 토큰 재발급 오류 수정

### DIFF
--- a/src/apis/adminApi.ts
+++ b/src/apis/adminApi.ts
@@ -8,9 +8,8 @@ export const fetchAdminData = async () => {
         console.log("관리자 본인 정보 조회:", res.data);
         return res.data.data;
     } catch (error) {
-        const err = error as AxiosError<{ data?: { message?: string } }>;
-        const message = err.response?.data?.data?.message ?? "관리자 본인 정보를 조회할 수 없습니다.";
-        throw new Error(message);
+        console.log("관리 본인 정보 조회 오류:", error); 
+        throw error;
     }
 };
 

--- a/src/apis/loginApi.ts
+++ b/src/apis/loginApi.ts
@@ -1,0 +1,36 @@
+import axios, { AxiosError } from "axios";
+import axiosWithAuthorization from "../contexts/axiosWithAuthorization";
+
+// 관리자 로그인
+interface LoginRequest {
+    username: string;
+    password: string;
+}
+
+const axiosWithoutAuth = axios.create({
+    baseURL: import.meta.env.VITE_PUBLIC_KEYWE_SERVER_URI,
+    withCredentials: true,
+});
+
+export const adminLogin = async (payload: LoginRequest) => {
+    try {
+        const res = await axiosWithoutAuth.post('/auth/login', payload);
+        return res.data.data;
+    } catch (error) {
+        const err = error as AxiosError<{ data?: { message?: string } }>;
+        const message = err.response?.data?.data?.message ?? "관리자 로그인에 실패했습니다.";
+        throw new Error(message);
+    }
+};
+
+// 관리자 로그아웃
+export const adminLogout = async () => {
+    try {
+        const res = await axiosWithAuthorization.post(`/auth/logout`);
+        return res.data.data;
+    } catch (error) {
+        const err = error as AxiosError<{ data?: { message?: string } }>;
+        const message = err.response?.data?.data?.message ?? "관리자 로그아웃에 실패했습니다.";
+        throw new Error(message);
+    }
+}

--- a/src/components/Admin/AdminLoginBox.tsx
+++ b/src/components/Admin/AdminLoginBox.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
-import axios from "axios";
 import { useNavigate } from "react-router-dom";
 import "./css/AdminLoginBox.css";
 import ReusableButton from "../buttons/ReusableButton";
+import { adminLogin } from "../../apis/loginApi";
 
 interface AdminLoginProps {
   onLogin: () => void;
@@ -16,25 +16,20 @@ const AdminLogin: React.FC<AdminLoginProps> = ({ onLogin }) => {
 
   const handleLogin = async () => {
     try {
-      const response = await axios.post("http://localhost:8082/auth/login", {
+      const response = await adminLogin({
         username: adminId,
         password: password,
       });
-
-      if (response.data.success) {
-        const token = response.data.data.accessToken;
+    const token = response.accessToken;
+      if (token) {
         localStorage.setItem("accessToken", token);
-
         onLogin();
         navigate("/dashboard");
       } else {
-        setError("로그인 실패: 서버 응답 오류");
+        setError("로그인 실패: 엑세스 토큰이 없음");
       }
-    } catch (err: any) {
-      const message = err?.response?.data?.data?.message;
-      if (message) {
-        setError(message);
-      }
+    } catch (error: any) {
+      setError(error.message); 
     }
   };
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,34 +2,26 @@ import './css/Header.css';
 import Logo from '../../assets/images/KEYWE_logo-white.png';
 import ReusableButton from '../buttons/ReusableButton';
 import { useNavigate } from 'react-router-dom';
-import axios from 'axios';
+
+import { adminLogout } from '../../apis/loginApi';
 
 const Header = () => {
   const navigate = useNavigate();
 
   const handleLogout = async () => {
-    const confirmed = window.confirm("로그아웃하시겠습니까?");
+    const confirmed = window.confirm("로그아웃 하시겠습니까?");
     if (!confirmed) return;
 
-    const token = localStorage.getItem("accessToken");
-
     try {
-      await axios.post(
-        "http://localhost:8082/auth/logout",
-        {},
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-          withCredentials: true,
-        }
-      );
-    } catch (err) {
-      console.warn("로그아웃 API 실패 (무시하고 계속 진행)", err);
+      await adminLogout();
+      localStorage.clear();
+      navigate("/admin/login");
+    } catch (err: any) {
+      const message = err?.message ?? "로그아웃 실패";
+      alert(message); 
+      console.warn("관리자 로그아웃 실패:", err);
+      navigate("/admin/login");
     }
-
-    localStorage.clear();
-    navigate("/admin/login");
   };
 
   return (

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -17,6 +17,7 @@ const Header = () => {
       localStorage.clear();
       navigate("/admin/login");
     } catch (err: any) {
+      localStorage.clear();
       const message = err?.message ?? "로그아웃 실패";
       alert(message); 
       console.warn("관리자 로그아웃 실패:", err);

--- a/src/contexts/axiosWithAuthorization.tsx
+++ b/src/contexts/axiosWithAuthorization.tsx
@@ -1,9 +1,15 @@
 import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+
 const getAccessToken = (): string | null => {
   return localStorage.getItem("accessToken");
 };
 
 const axiosWithAuthorization: AxiosInstance = axios.create({
+  baseURL: import.meta.env.VITE_PUBLIC_KEYWE_SERVER_URI,
+  withCredentials: true,
+});
+
+const axiosWithoutAuth: AxiosInstance = axios.create({
   baseURL: import.meta.env.VITE_PUBLIC_KEYWE_SERVER_URI,
   withCredentials: true,
 });
@@ -23,32 +29,36 @@ axiosWithAuthorization.interceptors.response.use(
   async (error: AxiosError) => {
     const originalRequest = error.config as AxiosRequestConfig & { _retry?: boolean };
 
-    if (error.response?.status === 401 && !originalRequest._retry && originalRequest.url !== "/auth/logout") {
+    console.log("401 발생한 요청 경로:", originalRequest.url);
+
+    if (error.response?.status === 401 && !originalRequest._retry && originalRequest.url !== "/auth/reissue") {
       originalRequest._retry = true;
       console.warn("401 에러 발생하여 엑세스 토큰 재발급 시도");
 
       try {
-        const res = await axios.post(
+        const accessToken = getAccessToken(); 
+
+        const res = await axiosWithoutAuth.post(
           "/auth/reissue",
           {},
           {
-            headers: {
-              Authorization: `Bearer ${getAccessToken()}`
-            },
             withCredentials: true,
+            headers: {
+              Authorization: `Bearer ${accessToken}`, 
+            },
           }
         );
 
-        const newAccessToken = res.headers["authorization"];
+        const newAccessToken = res.headers["authorization"]?.replace("Bearer ", "");
+
         if (newAccessToken) {
-          const tokenValue = newAccessToken.replace("Bearer ", "");
-          localStorage.setItem("accessToken", tokenValue);
+          localStorage.setItem("accessToken", newAccessToken);
 
           originalRequest.headers = originalRequest.headers || {};
-          originalRequest.headers.Authorization = `Bearer ${tokenValue}`;
+          originalRequest.headers['Authorization'] = `Bearer ${newAccessToken}`;
           console.info("엑세스 토큰 재발급 성공 및 재요청 수행");
-
-          return axiosWithAuthorization(originalRequest); 
+        
+          return axiosWithAuthorization.request(originalRequest);
         }
         // 엑세스 토큰을 받지 못했을 경우
         return Promise.reject(new Error("새로운 accessToken을 받지 못했습니다."));

--- a/src/contexts/axiosWithAuthorization.tsx
+++ b/src/contexts/axiosWithAuthorization.tsx
@@ -23,7 +23,7 @@ axiosWithAuthorization.interceptors.response.use(
   async (error: AxiosError) => {
     const originalRequest = error.config as AxiosRequestConfig & { _retry?: boolean };
 
-    if (error.response?.status === 401 && !originalRequest._retry) {
+    if (error.response?.status === 401 && !originalRequest._retry && originalRequest.url !== "/auth/logout") {
       originalRequest._retry = true;
       console.warn("401 에러 발생하여 엑세스 토큰 재발급 시도");
 
@@ -54,6 +54,7 @@ axiosWithAuthorization.interceptors.response.use(
         return Promise.reject(new Error("새로운 accessToken을 받지 못했습니다."));
       } catch (refreshError) {
         console.error("엑세스 토큰 재발급 실패:", refreshError);
+        localStorage.clear(); 
         window.location.href = "/admin/login";
         return Promise.reject(refreshError);
       }

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## 🔷 관련 Jira Ticket ID

[KW-318]

---
## 📌 작업 내용 및 특이사항

- axiosWithAuthorization 인스턴스에 요청/응답 인터셉터를 설정하여 응답에서 401 에러가 발생하면 '/auth/reissue' 엔드포인트로 리프레시 토큰을 포함한 요청을 전송하고 새 엑세스 토큰을 발급받은 후 원요청을 재시도하도록 구현하였습니다.
- 로그인 요청은 adminLogin 함수에서 axiosWithoutAuth를 통해 수행, 로그아웃 요청은 adminLogout 함수에서 axiosWithAuthorization를 통해 수행됩니다.


---
## 📚 참고사항

[크롬 쿠키 정책 (80버전): None, Strict, Lax에 대해]
- https://velog.io/@yena1025/%ED%81%AC%EB%A1%AC-%EC%BF%A0%ED%82%A4-%EC%A0%95%EC%B1%85-80%EB%B2%84%EC%A0%84-None-Strict-Lax%EC%97%90-%EB%8C%80%ED%95%B4

[Access-Control-Expose-Headers (헤더 접근)]
- https://velog.io/@hyunn/Access-Control-Expose-Headers-%ED%97%A4%EB%8D%94-%EC%A0%91%EA%B7%BC


[KW-318]: https://teamdoubleo.atlassian.net/browse/KW-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ