### PR TITLE
[KW-347] feat: 출입증 발급 관리 페이지 API 연결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,10 @@ import IssueDetailPage from './pages/IssueDetailPage';
 import PrivateRoute from './contexts/PrivateRoute';
 import AdminPasswordPage from './pages/AdminPasswordPage';
 import AdminAccessPolicyPage from './pages/AdminAccessPolicyPage';
+// import PatientListPage from './pages/PatientListPage';
+// import PatientDetailPage from './pages/PatientDetailPage';
+import PassPendingPage from './pages/PassPendingPage';
+import PendingDetailPage from './pages/PendingDetailPage';
 
 function App() {
   return (
@@ -32,11 +36,16 @@ function App() {
           <Route path="/dashboardstats" element={<DashboardStats />} />
           <Route path="/dashboardpass" element={<DashboardPass />} />
           <Route path="/admin/mypage" element={<AdminMyPage />} />
+          <Route path="/passpending" element={<PassPendingPage />} />
+          <Route path="/pendingdetail/:pendingId" element={<PendingDetailPage />} />
           <Route path="/issuehistory" element={<IssueHistoryPage />} />
           <Route path="/issuedetail/:requestId" element={<IssueDetailPage />} />
           <Route path="/entryhistory" element={<EntryHistoryPage />} />
+          {/* <Route path="/patientlist" element={<PatientListPage />} />
+          <Route path="/patientdetail/:patientId" element={<PatientDetailPage />} /> */}
           <Route path="/adminpassword" element={<AdminPasswordPage />} />
           <Route path="/admin/accesspolicy" element={<AdminAccessPolicyPage />} />
+
         </Route>
       </Routes>
     </Router>

--- a/src/apis/passApi.ts
+++ b/src/apis/passApi.ts
@@ -23,3 +23,32 @@ export const fetchIssuedPassLog = async (page: number) => {
         throw error;
     }
 };
+
+// 출입증 신청 요청 목록 조회
+export const fetchPassPending = async (page: number) => {
+    try {
+        const res = await axiosWithAuthorization.get(`/pass-logs/pending?page=${page}`);
+        console.log("출입증 신청 요청 목록 조회:", res.data);
+        return res.data.data;
+    } catch (error) {
+        console.log("출입증 신청 요청 목록 조회 오류:", error); 
+        throw error;
+    }
+};
+
+// 보호자 신청 승인/거절
+export const reviewPass = async (passId: number, issuanceStatus: "ISSUED" | "REJECTED") => {
+    try {
+        const res = await axiosWithAuthorization.post(`/pass-logs`, {
+            passId,
+            issuanceStatus,
+        });
+        console.log("보호자 신청 승인/거절:", res.data);
+        return res.data.data;
+    } catch (error) {
+        console.log("보호자 신청 승인/거절 오류:", error); 
+        throw error;
+    }
+};
+
+

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -9,10 +9,11 @@ import { MdOutlineKey, MdSettings } from 'react-icons/md';
 import SidebarButtonGray from '../../assets/images/KEYWE-sidebar-button-gray.png';
 import SidebarButtonGreen from '../../assets/images/KEYWE-sidebar-button-green.png';
 
-type Group = 'dashboard' | 'access' | 'admin';
+type Group = 'dashboard' | 'access' | 'pending' | 'admin';
 interface GroupOpenState {
   dashboard: boolean;
   access: boolean;
+  pending: boolean;
   admin: boolean;
 }
 
@@ -21,8 +22,10 @@ const menuPathMap: Record<string, string> = {
   '출입증 발급 현황': '/dashboardpass',
   '출입 내역': '/entryhistory',
   '출입증 발급 내역': '/issuehistory',
+  '출입증 발급 신청 내역': '/passpending',
   '관리자 정보': '/admin/mypage',
   '출입 정책': '/admin/accesspolicy',
+  
 };
 
 const Sidebar = () => {
@@ -40,6 +43,7 @@ const Sidebar = () => {
     return saved ? JSON.parse(saved) : {
       dashboard: true,
       access: true,
+      pending: true,
       admin: true,
     };
   });
@@ -89,6 +93,12 @@ const Sidebar = () => {
     } else if (location.pathname.includes('/changepassword') || location.pathname.includes('/admin')) {
       matchedMenu = '관리자 정보';
       matchedGroup = 'admin';
+    } else if (location.pathname.includes('/passpending')) {
+      matchedMenu = '출입증 발급 신청 내역';
+      matchedGroup = 'pending';
+    } else if (location.pathname.includes('/pendingdetail')) {
+      matchedMenu = '출입증 발급 신청 내역';
+      matchedGroup = 'pending';
     }
 
     if (matchedMenu && matchedGroup) {
@@ -141,6 +151,50 @@ const Sidebar = () => {
                   key={menu}
                   className={selectedMenu === menu ? 'selected' : ''}
                   onClick={() => handleMenuClick(menu, 'dashboard')}
+                >
+                  {isOpen ? (
+                    <span>{menu}</span>
+                  ) : (
+                    <div className="sidebar-collapsed-item" data-tooltip={menu}>
+                      <img
+                        src={selectedMenu === menu ? SidebarButtonGreen : SidebarButtonGray}
+                        alt="sidebar-icon"
+                        className="sidebar-collapsed-image"
+                      />
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </li>
+
+        {/* 출입증 발급 신청 그룹 */}
+        <li className="sidebar-menu-group">
+          <div
+            className={`sidebar-menu-title ${selectedGroup === 'pending' ? 'sidebar-group-selected' : ''}`}
+            onClick={() => toggleGroup('pending')}
+          >
+            {!isOpen ? (
+              <div className="sidebar-collapsed-item" data-tooltip="출입증 발급">
+                <MdOutlineKey className={`sidebar-menu-icon ${groupOpen.pending ? 'sidebar-menu-open' : ''}`} />
+              </div>
+            ) : (
+              <>
+                <span>출입증 발급</span>
+                <span style={{ marginLeft: 'auto' }}>
+                  {groupOpen.pending ? <IoChevronDownOutline className="sidebar-chevron-icon" /> : <IoChevronForward className="sidebar-chevron-icon" />}
+                </span>
+              </>
+            )}
+          </div>
+          {groupOpen.pending && (
+            <ul>
+              {['출입증 발급 신청 내역'].map(menu => (
+                <li
+                  key={menu}
+                  className={selectedMenu === menu ? 'selected' : ''}
+                  onClick={() => handleMenuClick(menu, 'pending')}
                 >
                   {isOpen ? (
                     <span>{menu}</span>

--- a/src/components/table/ApprovalTable.tsx
+++ b/src/components/table/ApprovalTable.tsx
@@ -1,22 +1,24 @@
 import React from "react";
 import "./css/ApprovalTable.css";
 
+type Column = {
+  key: string,
+  label: string;              
+};
+
 interface ApproveTableProps {
+  tableTitles: Column[];
   data: Record<string, any>[];
   onApprove?: (id: number) => void;
   onReject?: (id: number) => void;
+  onRowClick?: (row: Record<string, any>) => void;
   idKey?: string; 
 }
 
-const ApproveTable: React.FC<ApproveTableProps> = ({ data, onApprove, onReject, idKey = "requestId"}) => {
-
-  const tableTitles = [
-    { key: "requestId", label: "권한 요청 ID" },
-    { key: "requestor", label: "요청 보낸 사람" },
-    { key: "requestArea", label: "권한 요청 구역" },
-    { key: "reason", label: "요청 사유" },
-    { key: "date", label: "신청일자" },
-  ];
+const ApproveTable: React.FC<ApproveTableProps> = ({ 
+  tableTitles, data, onApprove, onReject, 
+  idKey = "passId", onRowClick
+}) => {
 
   return (
     <div className="approval-table-wrapper">
@@ -30,21 +32,31 @@ const ApproveTable: React.FC<ApproveTableProps> = ({ data, onApprove, onReject, 
           </tr>
         </thead>
         <tbody>
-          {data.map((row, idx) => (
-            <tr key={idx}>
+          {data.map((row) => (
+            <tr
+              key={row[idKey]}
+              onClick={() => onRowClick?.(row)}
+              className={onRowClick ? "clickable-row" : ""}
+            >
               {tableTitles.map((col) => (
-                <td key={col.key}>{row[col.key]}</td>
+                <td key={`${row[idKey]}-${col.key}`}>{row[col.key]}</td>
               ))}
               <td className="approval-table-buttons">
                 <button
                   className="approval-table-approve-btn"
-                  onClick={() => onApprove?.(row[idKey])}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onApprove?.(row[idKey]);
+                  }}
                 >
                   승인
                 </button>
                 <button
                   className="approval-table-reject-btn"
-                  onClick={() => onReject?.(row[idKey])}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onReject?.(row[idKey]);
+                  }}
                 >
                   거절
                 </button>

--- a/src/components/table/css/ApprovalTable.css
+++ b/src/components/table/css/ApprovalTable.css
@@ -1,20 +1,28 @@
-.approval-table-wrapper {
+  .approval-table-wrapper {
     overflow-x: auto;
     background: white;
     border-radius: 8px;
     box-shadow: 0 0 6px rgba(0, 0, 0, 0.5);
+    color: black
+  }
+
+  .approval-table-title {
+    font-size: 20px;
+    font-weight: 700;
+    color: black
   }
   
   .approval-table {
-    min-width: 1200px;
-    font-family: sans-serif;
-    table-layout: fixed;
+    width: 100%;             
+    table-layout: auto;      
     border-collapse: collapse;
+    color: black
   }
   
   .approval-table thead {
     background-color: #f5f5f5;
     text-align: left;
+    color: black
   }
   
   .approval-table th,
@@ -23,11 +31,12 @@
     height: 30px;     
     padding: 8px 50px;
     border-bottom: 1px solid #e0e0e0;
-    white-space: nowrap;
+    color: black;
   }
   
   .approval-table-name {
     font-weight: 500;
+    color: black
   }
 
 
@@ -80,4 +89,17 @@
   .approval-table-reject-btn:focus {
     outline: none;
     box-shadow: none;
+  }
+
+  .approval-table .clickable-row {
+    cursor: pointer;
+  }
+  
+  .approval-table .clickable-row:hover {
+    background-color: #f0f8ff; 
+  }
+
+  .approval-table th,
+  .approval-table td {
+    white-space: nowrap;
   }

--- a/src/pages/EntryHistoryPage.tsx
+++ b/src/pages/EntryHistoryPage.tsx
@@ -14,7 +14,7 @@ const entryHistoryColumns = [
     { key: "memberId", label: "사용자ID" },
     { key: "memberName", label: "출입자명" },
     { key: "passId", label: "출입증ID" },
-    { key: "areaId", label: "출입구역ID" },
+    { key: "areaCode", label: "출입구역ID" },
     { key: "areaName", label: "출입구역명" },
     { key: "createdDt", label: "출입시간"},
 ]

--- a/src/pages/PassPendingPage.tsx
+++ b/src/pages/PassPendingPage.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from 'react-router-dom';
+
+import Layout from '../components/layout/Layout';
+import Background from '../components/background/Background';
+import Breadcrumb from '../components/breadcrumb/Breadcrumb';
+import ApproveTable from "../components/table/ApprovalTable.tsx";
+import Pagination from '../components/table/Pagination.tsx';
+
+import './css/PassPendingPage.css';
+
+import { fetchPassPending, reviewPass } from "../apis/passApi.ts";
+
+const pendingColumns = [
+    { key: "passId", label: "보호자ID"},
+    { key: "guardianName", label: "보호자명" },
+    { key: "patientCode", label: "환자번호" },
+    { key: "createdDt", label: "발급요청일자"},
+]
+
+const breadCrumbInfo = {
+    currentPage: "출입증 발급",
+    currentSidebarItem: "출입증 발급 신청 내역"
+};
+
+const PassPendingPage = () => {
+  const [pendingList, setPendingList] = useState([]);
+  const [totalPages, setTotalPages] = useState(1);
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const navigate = useNavigate();
+
+  const loadData = async () => {
+    try {
+      const data = await fetchPassPending(currentPage - 1); 
+      setPendingList(data.content);
+      setTotalPages(data.totalPages);
+    } catch (err) {
+      console.error("출입증 발급 신청 내역 불러오기 실패:", err);
+    }
+  };
+
+  useEffect(() => {
+      loadData();
+  }, [currentPage]);
+
+  const handleApprove = async (passId: number) => {
+    try {
+      await reviewPass(passId, "ISSUED");
+      alert("출입증 발급이 승인되었습니다.");
+      loadData();
+    } catch (err) {
+      alert("승인 처리를 실패했습니다.");
+    }
+  };
+
+  const handleReject = async (passId: number) => {
+    try {
+      await reviewPass(passId, "REJECTED");
+      alert("출입증 발급이 거절되었습니다.");
+      loadData();
+    } catch (err) {
+      alert("거절 처리를 실패했습니다.");
+    }
+  };
+
+  return (
+    <>
+      <Background />
+      <Layout>
+        <Breadcrumb 
+            currentPage={breadCrumbInfo.currentPage}
+            currentSidebarItem={breadCrumbInfo.currentSidebarItem}
+        />
+          <div className="pass-pending-container">
+            <div className="pass-pending-title">출입증 발급 신청 내역 조회</div>
+            <ApproveTable 
+                tableTitles={pendingColumns} 
+                data={pendingList}
+                onRowClick={(row) => navigate(`/pendingdetail/${row.passId}`, { state: row })}
+                onApprove={handleApprove}
+                onReject={handleReject}
+            />
+            <Pagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              onPageChange={setCurrentPage}
+            />
+        </div>
+      </Layout>
+    </>
+  );
+};
+
+export default PassPendingPage;

--- a/src/pages/PendingDetailPage.tsx
+++ b/src/pages/PendingDetailPage.tsx
@@ -1,0 +1,68 @@
+import { useLocation } from 'react-router-dom';
+
+import Layout from '../components/layout/Layout.tsx';
+import Background from '../components/background/Background.tsx';
+import Breadcrumb from '../components/breadcrumb/Breadcrumb.tsx';
+import DefaultTable from '../components/table/DefaultTable.tsx';
+
+import './css/PendingDetailPage.css';
+
+const breadCrumbInfo = {
+    currentPage: "출입증 발급",
+    currentSidebarItem: "출입증 발급 신청 내역"
+};
+
+const pendingColumn = [
+    { key: "passId", label: "보호자ID"},
+    { key: "guardianName", label: "보호자명" },
+    { key: "patientCode", label: "환자번호" },
+    { key: "createdDt", label: "발급요청일자"},
+]
+
+const PendingDetailPage = () => {
+  const location = useLocation();
+  const data = location.state;
+  const pending = [data]; 
+
+  return (
+    <>
+      <Background />
+      <Layout>
+        <Breadcrumb 
+            currentPage={breadCrumbInfo.currentPage}
+            currentSidebarItem={breadCrumbInfo.currentSidebarItem}
+        />
+
+          <div className="pending-detail-container">
+            <div className="pending-detail-title">출입증 발급 신청 내역 상세 조회</div>
+            <DefaultTable 
+                tableTitles={pendingColumn} 
+                data={pending}
+            />
+            <br /><br />
+            <div className="pending-detail-title">보호자 상세 정보</div>
+                <div className="pending-detail-table-wrapper">
+                    <table className="pending-detail-table">
+                        <tbody>
+                        <tr>
+                            <td className="pending-detail-table-label-cell">환자명</td>
+                            <td>{data.patientName}</td>
+                        </tr>
+                        <tr>
+                            <td className="pending-detail-table-label-cell">보호자명</td>
+                            <td>{data.guardianName}</td>
+                        </tr>
+                        <tr>
+                            <td className="pending-detail-table-label-cell">보호자 연락처</td>
+                            <td>{data.guardianContact}</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+      </Layout>
+    </>
+  );
+};
+
+export default PendingDetailPage;

--- a/src/pages/css/PassPendingPage.css
+++ b/src/pages/css/PassPendingPage.css
@@ -1,0 +1,14 @@
+  .pass-pending-container {
+    width: fit-content;
+    margin-top: 0px;
+    margin-left: 10px;
+    padding: 20px;
+    background-color: transparent;
+  }
+  
+  .pass-pending-title {
+    font-size: 20px;
+    font-weight: 700;
+    margin-bottom: 16px;
+    color: #333;
+  }

--- a/src/pages/css/PendingDetailPage.css
+++ b/src/pages/css/PendingDetailPage.css
@@ -1,0 +1,46 @@
+.pending-detail-container {
+    width: fit-content;
+    margin-top: 0px;
+    margin-left: 10px;
+    padding: 20px;
+    background-color: transparent;
+  }
+  
+  .pending-detail-title {
+    font-size: 20px;
+    font-weight: 700;
+    margin-bottom: 16px;
+    color: #333;
+  }
+
+  .pending-detail-table-wrapper {
+    overflow-x: auto;
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 0 6px rgba(0, 0, 0, 0.5);
+    color: black
+  }
+
+  .pending-detail-table {
+    width: 100%;            
+    table-layout: auto;       
+    border-collapse: collapse;
+    background-color: white;
+  }
+  
+  .pending-detail-table td {
+    padding: 10px 26px;
+    border: 1px solid #ccc;
+    width: 180px;
+    background-color: #fff;
+  }
+  
+  .pending-detail-table-label-cell {
+    font-weight: bold;
+    background-color: #f9f9f9;
+    width: 180px;
+  }
+
+  .pending-detail-table td:nth-child(2) {
+    width: 700px; 
+  }


### PR DESCRIPTION
## 🔷 관련 Jira Ticket ID

[KW-347]

---
## 📌 작업 내용 및 특이사항

- 출입증 요청 목록 조회 페이지(PassPendingPage)와 출입증 요청 상세 조회 페이지(PendingDetailPage)에 출입증 요청 목록 조회, 보호자 신청 승인/거절 API를 연결하였습니다.
- PassPendingPage에서 요청 내역 항목 클릭 시 navigate의 state를 통해 상세 데이터를 PendingDetailPage로 전달하도록 구현하였습니다.

---
## 📚 참고사항

- '출입 내역 조회'와 '출입증 발급 내역 조회'의 출입구역ID 명칭을 'areaCode'로 통일함.


[KW-347]: https://teamdoubleo.atlassian.net/browse/KW-347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ