### PR TITLE
[KW-613] fix: ApprovalTable buttons 위치 조정

### DIFF
--- a/src/components/table/css/ApprovalTable.css
+++ b/src/components/table/css/ApprovalTable.css
@@ -54,7 +54,7 @@
 .approval-table-buttons {
   display: flex;
   gap: 8px;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
 }
 


### PR DESCRIPTION
## 🔷 관련 Jira Ticket ID

[KW-613]

---
## 📌 작업 내용 및 특이사항

- ApprovalTable buttons의 justify-content를 center에서 flex-start 정렬로 변경하였습니다.

---
## 📚 참고사항

-


[KW-613]: https://teamdoubleo.atlassian.net/browse/KW-613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ