### PR TITLE
[KW-635] feat: 출입 로그 서비스 상태에 따른 장애 격리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import { useEffect } from 'react';
 
 import DashboardStats from './pages/DashboardStats'
 import DashboardPass from './pages/DashboardPass'
@@ -17,6 +18,19 @@ import PendingDetailPage from './pages/PendingDetailPage';
 import WarningPage from './pages/WarningPage';
 
 function App() {
+  
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      sessionStorage.setItem('reloaded', 'true');
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, []);
+
   return (
     <Router>
       <Routes>

--- a/src/apis/passApi.ts
+++ b/src/apis/passApi.ts
@@ -4,7 +4,7 @@ import axiosWithAuthorization from "../contexts/axiosWithAuthorization";
 export const fetchEntryPassLog = async (page: number) => {
     try {
         const res = await axiosWithAuthorization.get(`/pass-logs/enter?page=${page}`);
-        console.log("출입 내역 조회:", res.data);
+        console.log("---> 출입 내역 조회:", res.data);
         return res.data.data;
     } catch (error) {
         console.log("출입 내역 조회 오류:", error); 
@@ -27,7 +27,7 @@ export const fetchIssuedPassLog = async (page: number) => {
 // 출입증 신청 요청 목록 조회
 export const fetchPassPending = async (page: number) => {
     try {
-        const res = await axiosWithAuthorization.get(`/pass-logs/pending?page=${page}`);
+        const res = await axiosWithAuthorization.get(`/admin-passes/pending?page=${page}`);
         console.log("출입증 신청 요청 목록 조회:", res.data);
         return res.data.data;
     } catch (error) {
@@ -39,7 +39,7 @@ export const fetchPassPending = async (page: number) => {
 // 보호자 신청 승인/거절
 export const reviewPass = async (passId: number, issuanceStatus: "ISSUED" | "REJECTED") => {
     try {
-        const res = await axiosWithAuthorization.post(`/pass-logs`, {
+        const res = await axiosWithAuthorization.post(`/admin-passes/approve`, {
             passId,
             issuanceStatus,
         });

--- a/src/components/_Admin/AdminLoginBox.tsx
+++ b/src/components/_Admin/AdminLoginBox.tsx
@@ -5,6 +5,7 @@ import ReusableButton from "../buttons/ReusableButton";
 import ReusableInput from "../input/ReusableInput";
 
 import { adminLogin } from "../../apis/loginApi";
+import { fetchEntryPassLog } from "../../apis/passApi";
 
 interface AdminLoginProps {
   onLogin: () => void;
@@ -26,7 +27,15 @@ const AdminLogin: React.FC<AdminLoginProps> = ({ onLogin }) => {
       if (token) {
         localStorage.setItem("accessToken", token);
         onLogin();
-        navigate("/dashboardstats");
+        try {
+          await fetchEntryPassLog(0);
+          navigate("/dashboardstats");
+        } catch (error) {
+          console.error("<--- 출입 로그 조회 실패:", error);  
+          navigate("/admin/mypage");
+        }
+
+
       } else {
         setError("로그인 실패: 엑세스 토큰이 없음");
       }

--- a/src/components/input/ReusableInput.tsx
+++ b/src/components/input/ReusableInput.tsx
@@ -13,6 +13,7 @@ const ReusableInput: React.FC<ReusableInputProps> = ({
   className = "",
   type,
   showToggle = false,
+  iconClassName, 
   ...props
 }) => {
   const [showPassword, setShowPassword] = useState(false);
@@ -31,7 +32,7 @@ const ReusableInput: React.FC<ReusableInputProps> = ({
         />
         {isPassword && (
           <span
-            className="reusable-input-icon"
+            className={`reusable-input-icon ${iconClassName || ''}`} 
             onClick={() => setShowPassword((prev) => !prev)}
           >
             {showPassword ? <IoEyeOff /> : <IoEye />}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -80,7 +80,6 @@ const Header = () => {
           src={Logo}
           alt="KEYWE Logo"
           className="header-logo-image"
-          onClick={() => navigate('/dashboardstats')}
         />
       </div>
       <div className="header-right-wrapper">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -13,6 +13,8 @@ import { MdTextSnippet } from "react-icons/md";
 import SidebarButtonGray from '../../assets/images/KEYWE-sidebar-button-gray.png';
 import SidebarButtonGreen from '../../assets/images/KEYWE-sidebar-button-green.png';
 
+import { usePassLogContext } from '../../contexts/PassLogContext';
+
 type Group = 'dashboard' | 'access' | 'pending' | 'patient' | 'admin';
 interface GroupOpenState {
   dashboard: boolean;
@@ -57,6 +59,8 @@ const Sidebar = () => {
 
   const [selectedMenu, setSelectedMenu] = useState<string>('');
   const [selectedGroup, setSelectedGroup] = useState<Group | null>(null);
+
+  const { isPassLogAvailable } = usePassLogContext();
 
   const toggleSidebar = () => setIsOpen(prev => !prev);
 
@@ -140,6 +144,7 @@ const Sidebar = () => {
 
       <ul className="sidebar-menu">
         {/* 대시보드 그룹 */}
+        {isPassLogAvailable && (
         <li className="sidebar-menu-group">
           <div
             className={`sidebar-menu-title ${selectedGroup === 'dashboard' ? 'sidebar-group-selected' : ''}`}
@@ -182,6 +187,7 @@ const Sidebar = () => {
             </ul>
           )}
         </li>
+        )}
 
         {/* 환자 정보 그룹 */}
         <li className="sidebar-menu-group">
@@ -272,6 +278,7 @@ const Sidebar = () => {
         </li>
 
         {/* 출입 로그 그룹 */}
+        {isPassLogAvailable && (
         <li className="sidebar-menu-group">
           <div
             className={`sidebar-menu-title ${selectedGroup === 'access' ? 'sidebar-group-selected' : ''}`}
@@ -314,6 +321,7 @@ const Sidebar = () => {
             </ul>
           )}
         </li>
+        )}
 
         {/* 관리페이지 그룹 */}
         <li className="sidebar-menu-group">

--- a/src/components/layout/css/Header.css
+++ b/src/components/layout/css/Header.css
@@ -16,7 +16,6 @@
 
 .header-logo-image {
   height: 40px;
-  cursor: pointer;
   margin-left: -30px;
 }
 

--- a/src/contexts/PassLogContext.tsx
+++ b/src/contexts/PassLogContext.tsx
@@ -1,0 +1,74 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { fetchEntryPassLog } from '../apis/passApi';
+
+export interface PassLogContextType {
+  isPassLogAvailable: boolean;
+  checkAccessLogAvailability: () => Promise<boolean>;  
+  setIsPassLogAvailable: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export const PassLogContext = createContext<PassLogContextType>({
+  isPassLogAvailable: true, 
+  checkAccessLogAvailability: async () => false,
+  setIsPassLogAvailable: () => {},
+});
+
+export const PassLogProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [isPassLogAvailable, setIsPassLogAvailable] = useState(false);
+
+  const checkAccessLogAvailability = async (): Promise<boolean> => {
+    try {
+      await fetchEntryPassLog(0);
+      setIsPassLogAvailable(true);
+      return true;
+    } catch (error) {
+      console.error('<---출입 로그 사용 불가--->:', error);
+      setIsPassLogAvailable(false);
+      return false;
+    }
+  };
+
+  useEffect(() => {
+    const reloaded = sessionStorage.getItem('reloaded');
+    
+    if (reloaded === 'true') {
+      console.log('새로고침 후 checkAccessLogAvailability 실행');
+      checkAccessLogAvailability();
+      // sessionStorage.removeItem('reloaded');
+    }
+
+    const intervalId = setInterval(() => {
+      checkAccessLogAvailability();
+    }, 20000);
+
+    const handleStorageChange = (event: StorageEvent) => {
+      if (event.key === 'accessToken') {
+        const token = event.newValue;
+        if (token) {
+          console.log('로그인 후 checkAccessLogAvailability 실행');
+          checkAccessLogAvailability();
+        }
+      }
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+
+    return () => {
+      clearInterval(intervalId);
+      window.removeEventListener('storage', handleStorageChange);
+    };
+  }, []);
+
+  return (
+    <PassLogContext.Provider
+      value={{ 
+        isPassLogAvailable, 
+        checkAccessLogAvailability,
+        setIsPassLogAvailable, 
+      }}>
+      {children}
+    </PassLogContext.Provider>
+  );
+};
+
+export const usePassLogContext = () => useContext(PassLogContext);

--- a/src/contexts/PrivateRoute.tsx
+++ b/src/contexts/PrivateRoute.tsx
@@ -1,8 +1,16 @@
 import { Navigate, Outlet } from 'react-router-dom';
+import { PassLogProvider } from './PassLogContext';
 
 const PrivateRoute = () => {
   const isLoggedIn = !!localStorage.getItem('accessToken');
-  return isLoggedIn ? <Outlet /> : <Navigate to="/admin/login" replace />;
+
+  return isLoggedIn ? (
+    <PassLogProvider>
+      <Outlet />
+    </PassLogProvider>
+  ) : (
+    <Navigate to="/admin/login" replace />
+  );
 };
 
 export default PrivateRoute;

--- a/src/contexts/axiosWithAuthorization.tsx
+++ b/src/contexts/axiosWithAuthorization.tsx
@@ -29,7 +29,7 @@ axiosWithAuthorization.interceptors.response.use(
   async (error: AxiosError) => {
     const originalRequest = error.config as AxiosRequestConfig & { _retry?: boolean };
 
-    console.log("401 발생한 요청 경로:", originalRequest.url);
+    console.log(`응답 에러 발생 [${error.response?.status}] 요청 경로: ${originalRequest.url}`);
 
     if (error.response?.status === 401 && !originalRequest._retry && originalRequest.url !== "/auth/reissue") {
       originalRequest._retry = true;

--- a/src/pages/DashboardPass.tsx
+++ b/src/pages/DashboardPass.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+import { usePassLogContext } from "../contexts/PassLogContext.tsx";
+
 import Layout from '../components/layout/Layout';
 import Background from '../components/background/Background';
 import ChartGrowPassRequest from '../components/dashboard/pass/ChartGrowPassRequest';
@@ -6,6 +8,7 @@ import SearchFilter from '../components/dashboard/pass/SearchFilter';
 import ChartLinePassByTeam from '../components/dashboard/pass/ChartLinePassByTeam';
 import { fetchAdminData } from '../apis/adminApi';
 import Loading from '../components/loading/Loading';
+import Warning from '../components/warning/Warning';
 
 import '../components/loading/css/Loading.css'
 import './css/DashboardPass.css';
@@ -22,6 +25,8 @@ const DashboardPass = () => {
   const [hospitalId, setHospitalId] = useState<string | null>(null);
   const [filterOptions, setFilterOptions] = useState<FilterOptions | null>(null);
 
+  const { isPassLogAvailable } = usePassLogContext();
+
   useEffect(() => {
     fetchAdminData()
       .then((admin) => {
@@ -33,6 +38,17 @@ const DashboardPass = () => {
       });
   }, []);
 
+  if (!isPassLogAvailable) {
+    return (
+      <>
+        <Background />
+        <Layout>
+          <Warning />
+        </Layout>
+      </>
+    );
+  }
+
   return (
     <>
       <Background />
@@ -41,7 +57,7 @@ const DashboardPass = () => {
           {!hospitalId && (
             <div className="loading-overlay">
               <Loading />
-              <div className="loading-text">병원 정보를 불러오는 중입니다...</div>
+              <div className="loading-text">출입증 발급 현황을 불러오는 중입니다...</div>
             </div>
           )}
 

--- a/src/pages/DashboardStats.tsx
+++ b/src/pages/DashboardStats.tsx
@@ -1,3 +1,5 @@
+import { usePassLogContext } from "../contexts/PassLogContext.tsx";
+
 import StatsSummaryCard from '../components/dashboard/stats/StatsSummaryCard';
 import ChartAreaTotalByHour from '../components/dashboard/stats/ChartAreaTotalByHour';
 import ChartSyncedTotalByPeriod from '../components/dashboard/stats/ChartSyncedTotalByPeriod';
@@ -7,9 +9,24 @@ import ChartLineBuildingAccess from '../components/dashboard/stats/ChartLineBuil
 import Layout from '../components/layout/Layout';
 import Background from '../components/background/Background';
 
+import Warning from '../components/warning/Warning';
+
 import './css/DashboardStats.css';
 
 const DashboardStats = () => {
+  const { isPassLogAvailable } = usePassLogContext();
+
+  if (!isPassLogAvailable) {
+    return (
+      <>
+        <Background />
+        <Layout>
+          <Warning />
+        </Layout>
+      </>
+    );
+  }
+
   return (
     <>
       <Background />

--- a/src/pages/EntryHistoryPage.tsx
+++ b/src/pages/EntryHistoryPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { usePassLogContext } from "../contexts/PassLogContext.tsx";
 
 import Layout from '../components/layout/Layout.tsx';
 import Background from '../components/background/Background.tsx';
@@ -6,6 +7,7 @@ import Breadcrumb from '../components/breadcrumb/Breadcrumb.tsx';
 import DefaultTable from '../components/table/DefaultTable.tsx';
 import Pagination from '../components/table/Pagination.tsx';
 import Loading from "../components/loading/Loading.tsx";
+import Warning from "../components/warning/Warning.tsx";
 
 import '../components/loading/css/Loading.css'
 import './css/EntryHistoryPage.css';
@@ -31,6 +33,8 @@ const EntryHistoryPage = () => {
   const [totalPages, setTotalPages] = useState(1);
   const [currentPage, setCurrentPage] = useState(1);
   const [isLoading, setIsLoading] = useState(false);
+  
+  const { isPassLogAvailable } = usePassLogContext();
 
   useEffect(() => {
     const loadData = async () => {
@@ -52,6 +56,17 @@ const EntryHistoryPage = () => {
 
     loadData();
   }, [currentPage]);
+
+  if (!isPassLogAvailable) {
+    return (
+      <>
+        <Background />
+        <Layout>
+          <Warning />
+        </Layout>
+      </>
+    );
+  }
 
   return (
     <>

--- a/src/pages/IssueHistoryPage.tsx
+++ b/src/pages/IssueHistoryPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from 'react-router-dom';
+import { usePassLogContext } from "../contexts/PassLogContext.tsx";
 
 import Layout from '../components/layout/Layout';
 import Background from '../components/background/Background';
@@ -7,6 +8,7 @@ import Breadcrumb from '../components/breadcrumb/Breadcrumb';
 import DefaultTable from '../components/table/DefaultTable';
 import Pagination from '../components/table/Pagination.tsx';
 import Loading from "../components/loading/Loading.tsx";
+import Warning from "../components/warning/Warning.tsx";
 
 import '../components/loading/css/Loading.css'
 import './css/IssueHistoryPage.css';
@@ -33,6 +35,8 @@ const IssueHistoryPage = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const [isLoading, setIsLoading] = useState(false);
 
+  const { isPassLogAvailable } = usePassLogContext();
+
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -57,6 +61,17 @@ const IssueHistoryPage = () => {
   
       loadData();
     }, [currentPage]);
+
+  if (!isPassLogAvailable) {
+    return (
+      <>
+        <Background />
+        <Layout>
+          <Warning />
+        </Layout>
+      </>
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
## 🔷 관련 Jira Ticket ID

[KW-635]

---
## 📌 작업 내용 및 특이사항

- 출입 로그 서비스 사용 가능 여부를 context로 관리하는 PassLogProvider를 추가하였고, 새로고침 및 로그인 시점, 그리고 일정 간격(20초)마다 checkAccessLogAvailability를 실행하도록 설정했습니다.
- 로그인 후 출입 로그 조회 결과에 따라 페이지 이동 처리를 구분하였습니다.
- isPassLogAvailable 값을 기반으로 Sidebar의 대시보드, 출입 로그 그룹 표시를 제어하였습니다.
- DashboardPass, DashboardStats, EntryHistoryPage, IssueHistoryPage에 Warning 컴포넌트를 추가하였습니다.

---
## 📚 참고사항

- '출입증 신청 요청 목록 조회', '보호자 신청 승인/거절' API 함수 엔드포인트를 각각 `/admin-passes/pending`, `/admin-passes/approve`로 변경하였습니다.
- 출입 로그 서비스 상태에 따라 로고 클릭 시 이동 경로를 구분하는 로직이 번거롭다고 판단되어 Header의 로고 onClick 핸들러를 삭제하였습니다.
- 현재는 fetchEntryPassLog 함수를 이용해서 출입 로그 서비스 사용 가능 여부를 확인하고 있지만 추후에는 출입 로그 서비스 전용 health-check API 함수로 대체할 예정입니다.


[KW-635]: https://teamdoubleo.atlassian.net/browse/KW-635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ